### PR TITLE
Replaced the csv module with unicodecsv

### DIFF
--- a/pantable/pantable.py
+++ b/pantable/pantable.py
@@ -41,7 +41,7 @@ First row,defaulted to be header row,can be disabled
 ```
 """
 
-import csv
+import unicodecsv as csv
 import fractions
 import io
 import panflute

--- a/pantable/pantable2csv.py
+++ b/pantable/pantable2csv.py
@@ -49,7 +49,7 @@ First row,defaulted to be header row,can be disabled
 ~~~
 """
 
-import csv
+import unicodecsv as csv
 import io
 import panflute
 import yaml

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['panflute>=1.8.2'],
+    install_requires=['panflute>=1.8.2', 'unicodecsv>=0.14.1'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
This fixes the lacking unicode support in the default python csv module, by
replacing it with the unicodecsv module instead of adding potential buggy code.

Fixes #14.