### PR TITLE
Allowing to run filters automatically

### DIFF
--- a/pantable/pantable.py
+++ b/pantable/pantable.py
@@ -278,7 +278,7 @@ def convert2table(options, data, **__):
     )
 
 
-def main(_=None):
+def main(doc=None):
     """
     Fenced code block with class table will be parsed using
     panflute.yaml_filter with the fuction convert2table above.
@@ -287,7 +287,8 @@ def main(_=None):
         panflute.yaml_filter,
         tag='table',
         function=convert2table,
-        strict_yaml=True
+        strict_yaml=True,
+        doc=doc
     )
 
 if __name__ == '__main__':

--- a/pantable/pantable2csv.py
+++ b/pantable/pantable2csv.py
@@ -69,7 +69,7 @@ def ast2markdown(ast):
     )
 
 
-def table2csv(elem, *__):
+def table2csv(elem, doc):
     """
     find Table element and return a csv table in code-block with class "table"
     """
@@ -118,7 +118,7 @@ def table2csv(elem, *__):
     return None
 
 
-def main(_=None):
+def main(doc=None):
     """
     Any native pandoc tables will be converted into the CSV table format used by pantable:
 
@@ -126,7 +126,10 @@ def main(_=None):
     - metadata in YAML
     - table in CSV
     """
-    panflute.run_filter(table2csv)
+    return panflute.run_filter(
+        table2csv,
+        doc=doc
+    )
 
 if __name__ == '__main__':
     main()

--- a/tests/pantable2csv/test_table2csv.py
+++ b/tests/pantable2csv/test_table2csv.py
@@ -14,7 +14,7 @@ def test_table2csv():
 : *abcd*
 """
     Panflute = convert_text(markdown)
-    code_block_converted = table2csv(*Panflute)
+    code_block_converted = table2csv(*Panflute, doc=None)
     code_block_referenced = CodeBlock('''---
 alignment: LRCD
 caption: '*abcd*'


### PR DESCRIPTION
Minor update to the run_filter and main function, to support running the filters
automatically, as documented here:
http://scorreia.com/software/panflute/guide.html#running-filters-automatically

This allows the user to add `panflute-filters` and `panflute-path` meta-data
fields to the pandoc document and in turn having all of these filters run by
just running pandoc as: `pandoc -F panflute ...`

Minor changes to the test was done, to reflect the new `doc` argument.
Tests passed for py3 on my machine, but still not for py2 (as previously noted).

I guess new tests should be added to demonstrate this, but I don't really know how to do this without invoking pandoc.  And to be honest, I haven't worked that much with Travis/CI to know the implications of doing this.  As far as I can see no other tests invoke pandoc.