### PR TITLE
Correct YAML key for alignment in README comparison chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ similar functionality. This filter is born after testing with theirs.
 <td>aligns = LRCD</td>
 <td>aligns = LRCD</td>
 <td></td>
-<td>aligns = LRCD</td>
+<td>alignment = LRCD</td>
 </tr>
 <tr class="odd">
 <td>width</td>


### PR DESCRIPTION
The chart that shows how different table filters handle properties has the wrong metadata property for this project.